### PR TITLE
feat: support @Optional fields in strict mode builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,26 @@ public class Car {
     @Buildable.Mandatory
     private String color;
 ```
+
+### Optional Fields
+
+When using the `STRICT` strategy, all constructor-matched fields are enforced by default.
+Fields can be marked as optional using `@Buildable.Optional`,
+allowing them to be omitted during the build process
+and defaulting to their inherent value (e.g., `null` for object references, `0` for numeric types).
+
+```java
+@Buildable(strategy = STRICT)
+public class Car {
+    private String brand;
+
+    @Buildable.Optional
+    private int year;
+```
+
+> **Note:** `@Buildable.Optional` cannot be combined with the `ALLOW_NULLS` strategy.
+> Doing so will result in a compilation error.
+
 ### Change Default Package
     
 A `CarBuilder` class will be generated in the same package as the source class with *builder* as suffix.

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.jonasg</groupId>
 		<artifactId>bob</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.6.0</version>
 	</parent>
 
 	<artifactId>bob-annotations</artifactId>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.jonasg</groupId>
 		<artifactId>bob</artifactId>
-		<version>0.5.0</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>bob-annotations</artifactId>

--- a/annotations/src/main/java/io/jonasg/bob/Buildable.java
+++ b/annotations/src/main/java/io/jonasg/bob/Buildable.java
@@ -1,5 +1,6 @@
 package io.jonasg.bob;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -44,7 +45,6 @@ public @interface Buildable {
 	 *
 	 * @return mandatory fields
 	 */
-
 	String[] mandatoryFields() default {};
 
 	/**
@@ -105,9 +105,10 @@ public @interface Buildable {
 	}
 
 	/**
-	 * Marks a field as optional. When the field is not set within the building
-	 * process, it will be null
+	 * Marks a field as optional. If not set during the building process,
+	 * the java default value for the field type will be used
 	 */
+	@Documented
 	@Retention(RetentionPolicy.SOURCE)
 	@Target(ElementType.FIELD)
 	@interface Optional {

--- a/annotations/src/main/java/io/jonasg/bob/Buildable.java
+++ b/annotations/src/main/java/io/jonasg/bob/Buildable.java
@@ -44,6 +44,7 @@ public @interface Buildable {
 	 *
 	 * @return mandatory fields
 	 */
+
 	String[] mandatoryFields() default {};
 
 	/**
@@ -101,6 +102,15 @@ public @interface Buildable {
 	@Retention(RetentionPolicy.SOURCE)
 	@Target(ElementType.FIELD)
 	@interface Mandatory {
+	}
+
+	/**
+	 * Marks a field as optional. When the field is not set within the building
+	 * process, it will be null
+	 */
+	@Retention(RetentionPolicy.SOURCE)
+	@Target(ElementType.FIELD)
+	@interface Optional {
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
 	<artifactId>bob</artifactId>
 	<packaging>pom</packaging>
-	<version>0.5.0</version>
+	<version>0.6.0-SNAPSHOT</version>
 
 	<properties>
 		<java.version>17</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
 	<artifactId>bob</artifactId>
 	<packaging>pom</packaging>
-	<version>0.6.0-SNAPSHOT</version>
+	<version>0.6.0</version>
 
 	<properties>
 		<java.version>17</java.version>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.jonasg</groupId>
 		<artifactId>bob</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.6.0</version>
 	</parent>
 
 	<artifactId>bob-processor</artifactId>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.jonasg</groupId>
 		<artifactId>bob</artifactId>
-		<version>0.5.0</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>bob-processor</artifactId>

--- a/processor/src/main/java/io/jonasg/bob/BuildableField.java
+++ b/processor/src/main/java/io/jonasg/bob/BuildableField.java
@@ -18,17 +18,18 @@ public record BuildableField(
 		String name,
 		boolean isConstructorArgument,
 		boolean isMandatory,
+		boolean isOptional,
 		Optional<String> setterMethodName,
 		TypeMirror type
 ) {
 
-	public static BuildableField fromConstructor(String fieldName, TypeMirror type) {
-		return new BuildableField(fieldName, true, false, Optional.empty(), type);
+	public static BuildableField fromConstructor(String fieldName, boolean isOptional,  TypeMirror type) {
+		return new BuildableField(fieldName, true, false, isOptional, Optional.empty(), type);
 	}
 
 	public static BuildableField fromSetter(String fieldName, boolean fieldIsMandatory, String setterMethodName,
 											TypeMirror type) {
-		return new BuildableField(fieldName, false, fieldIsMandatory, Optional.of(setterMethodName), type);
+		return new BuildableField(fieldName, false, fieldIsMandatory, false, Optional.of(setterMethodName), type);
 	}
 
 

--- a/processor/src/main/java/io/jonasg/bob/BuilderTypeSpecFactory.java
+++ b/processor/src/main/java/io/jonasg/bob/BuilderTypeSpecFactory.java
@@ -1,5 +1,7 @@
 package io.jonasg.bob;
 
+import static io.jonasg.bob.Strategy.PERMISSIVE;
+
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
 import com.palantir.javapoet.FieldSpec;
@@ -16,11 +18,6 @@ import io.jonasg.bob.definitions.GenericParameterDefinition;
 import io.jonasg.bob.definitions.ParameterDefinition;
 import io.jonasg.bob.definitions.SimpleTypeDefinition;
 import io.jonasg.bob.definitions.TypeDefinition;
-
-import javax.lang.model.element.Modifier;
-import javax.lang.model.type.PrimitiveType;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -28,8 +25,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static io.jonasg.bob.Strategy.PERMISSIVE;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
 
 public class BuilderTypeSpecFactory {
 
@@ -45,7 +44,8 @@ public class BuilderTypeSpecFactory {
 
 	private final String packageName;
 
-	protected BuilderTypeSpecFactory(TypeDefinition typeDefinition, Buildable buildable, Types typeUtils,
+	protected BuilderTypeSpecFactory(TypeDefinition typeDefinition, Buildable buildable,
+			Types typeUtils,
 			String packageName) {
 		this.typeDefinition = typeDefinition;
 		this.buildable = buildable;
@@ -66,10 +66,7 @@ public class BuilderTypeSpecFactory {
 		Stream<BuildableField> constructorBuildableFields = this.constructorDefinition.parameters()
 				.stream()
 				.filter(p -> fieldNames.contains(p.name()))
-				.map(p -> BuildableField.fromConstructor(p.name(),
-						typeDefinition.fields().stream().filter(field -> field.name().equals(p.name()))
-								.anyMatch(
-										fieldDefinition -> fieldDefinition.isAnnotatedWith(Buildable.Optional.class)),
+				.map(p -> BuildableField.fromConstructor(p.name(), isOptional(p),
 						p.type()));
 
 		Stream<BuildableField> setterBuildableFields = this.typeDefinition.getSetterMethods()
@@ -80,9 +77,17 @@ public class BuilderTypeSpecFactory {
 					boolean fieldIsMandatory = Arrays.stream(this.buildable.mandatoryFields())
 							.anyMatch(f -> Objects.equals(f, p.field().name()))
 							|| p.field().isAnnotatedWith(Buildable.Mandatory.class);
-					return BuildableField.fromSetter(p.field().name(), fieldIsMandatory, p.methodName(), p.type());
+					return BuildableField.fromSetter(p.field().name(), fieldIsMandatory, p.methodName(),
+							p.type());
 				});
-		return Stream.concat(constructorBuildableFields, setterBuildableFields).collect(Collectors.toList());
+		return Stream.concat(constructorBuildableFields, setterBuildableFields)
+				.collect(Collectors.toList());
+	}
+
+	private boolean isOptional(ParameterDefinition p) {
+		return typeDefinition.fields().stream().filter(field -> field.name().equals(p.name()))
+				.anyMatch(
+						fieldDefinition -> fieldDefinition.isAnnotatedWith(Buildable.Optional.class));
 	}
 
 	private ConstructorDefinition extractConstructorDefinitionFrom(TypeDefinition typeDefinition) {
@@ -90,7 +95,8 @@ public class BuilderTypeSpecFactory {
 				.filter(c -> c.isAnnotatedWith(Buildable.Constructor.class))
 				.collect(Collectors.toList());
 		if (buildableConstructors.size() > 1) {
-			throw new IllegalArgumentException("Only one constructor can be annotated with @Buildable.Constructor");
+			throw new IllegalArgumentException(
+					"Only one constructor can be annotated with @Buildable.Constructor");
 		}
 		if (buildableConstructors.isEmpty()) {
 			return typeDefinition.constructors().stream()
@@ -102,7 +108,8 @@ public class BuilderTypeSpecFactory {
 
 	public List<TypeSpec> typeSpecs() {
 		if (Arrays.asList(this.buildable.strategy()).contains(PERMISSIVE) &&
-				this.buildableFields.stream().anyMatch(f -> f.isMandatory() && !f.isConstructorArgument())) {
+				this.buildableFields.stream()
+						.anyMatch(f -> f.isMandatory() && !f.isConstructorArgument())) {
 			throw new StrategyConflictException(
 					"PERMISSIVE (default) strategy cannot be combined with Mandatory fields, consider "
 							+ "STRICT or STEP_WISE or remove the mandatory fields");
@@ -195,7 +202,8 @@ public class BuilderTypeSpecFactory {
 								TypeName.get(boxedType(field.type()))), field.name(), Modifier.PRIVATE,
 								Modifier.FINAL)
 						.initializer("$T.$L(\"" + field.name() + "\", \""
-								+ this.typeDefinition.typeName() + "\")", ValidatableField.class, methodName)
+								+ this.typeDefinition.typeName() + "\")", ValidatableField.class,
+								methodName)
 						.build();
 			}
 		} else {
@@ -355,7 +363,8 @@ public class BuilderTypeSpecFactory {
 			}
 		} else {
 			List<TypeVariableName> genericParameters = toTypeVariableNames(definition);
-			return ParameterizedTypeName.get(ClassName.get(definition.packageName(), definition.fullTypeName()),
+			return ParameterizedTypeName.get(
+					ClassName.get(definition.packageName(), definition.fullTypeName()),
 					genericParameters.toArray(new TypeName[0]));
 		}
 	}
@@ -364,8 +373,9 @@ public class BuilderTypeSpecFactory {
 		List<TypeVariableName> genericParameters = new ArrayList<>();
 		for (GenericParameterDefinition parameterDefinition : definition.genericParameters()) {
 			genericParameters
-					.add(TypeVariableName.get(parameterDefinition.name(), simpleClassNames(parameterDefinition.bounds())
-							.toArray(new TypeName[parameterDefinition.bounds().size()])));
+					.add(TypeVariableName.get(parameterDefinition.name(),
+							simpleClassNames(parameterDefinition.bounds())
+									.toArray(new TypeName[parameterDefinition.bounds().size()])));
 		}
 		return genericParameters;
 	}

--- a/processor/src/main/java/io/jonasg/bob/BuilderTypeSpecFactory.java
+++ b/processor/src/main/java/io/jonasg/bob/BuilderTypeSpecFactory.java
@@ -66,7 +66,12 @@ public class BuilderTypeSpecFactory {
 		Stream<BuildableField> constructorBuildableFields = this.constructorDefinition.parameters()
 				.stream()
 				.filter(p -> fieldNames.contains(p.name()))
-				.map(p -> BuildableField.fromConstructor(p.name(), p.type()));
+				.map(p -> BuildableField.fromConstructor(p.name(),
+						typeDefinition.fields().stream().filter(field -> field.name().equals(p.name()))
+								.anyMatch(
+										fieldDefinition -> fieldDefinition.isAnnotatedWith(Buildable.Optional.class)),
+						p.type()));
+
 		Stream<BuildableField> setterBuildableFields = this.typeDefinition.getSetterMethods()
 				.stream()
 				.filter(setter -> !eligibleConstructorParams
@@ -148,7 +153,11 @@ public class BuilderTypeSpecFactory {
 				.returns(builderType())
 				.addParameter(TypeName.get(field.type()), field.name());
 		if (field.isConstructorArgument() && isAnEnforcedConstructorPolicy() || field.isMandatory()) {
-			builder.addStatement("this.$L.set($L)", field.name(), field.name());
+			if (strategy().contains(Strategy.STRICT) && field.isOptional()) {
+				builder.addStatement("this.$L = $L", field.name(), field.name());
+			} else {
+				builder.addStatement("this.$L.set($L)", field.name(), field.name());
+			}
 		} else {
 			builder.addStatement("this.$L = $L", field.name(), field.name());
 		}
@@ -169,16 +178,26 @@ public class BuilderTypeSpecFactory {
 
 	protected FieldSpec generateField(BuildableField field) {
 		if (field.isConstructorArgument() && isAnEnforcedConstructorPolicy() || field.isMandatory()) {
-			String methodName = this.strategy().contains(Strategy.ALLOW_NULLS)
-					? "ofNullableField"
-					: "ofNoneNullableField";
-			return FieldSpec
-					.builder(ParameterizedTypeName.get(ClassName.get(ValidatableField.class),
-							TypeName.get(boxedType(field.type()))), field.name(), Modifier.PRIVATE,
-							Modifier.FINAL)
-					.initializer("$T.$L(\"" + field.name() + "\", \""
-							+ this.typeDefinition.typeName() + "\")", ValidatableField.class, methodName)
-					.build();
+			if (strategy().contains(Strategy.STRICT) && strategy().contains(Strategy.ALLOW_NULLS)
+					&& field.isOptional()) {
+				throw new StrategyConflictException(
+						"ALLOW_NULLS strategy cannot be combined with optional fields, consider removing the optional annotation or remove the ALLOW_NULLS strategy");
+			}
+			if (strategy().contains(Strategy.STRICT) && field.isOptional()) {
+				return FieldSpec.builder(TypeName.get(field.type()), field.name(), Modifier.PRIVATE)
+						.build();
+			} else {
+				String methodName = this.strategy().contains(Strategy.ALLOW_NULLS)
+						? "ofNullableField"
+						: "ofNoneNullableField";
+				return FieldSpec
+						.builder(ParameterizedTypeName.get(ClassName.get(ValidatableField.class),
+								TypeName.get(boxedType(field.type()))), field.name(), Modifier.PRIVATE,
+								Modifier.FINAL)
+						.initializer("$T.$L(\"" + field.name() + "\", \""
+								+ this.typeDefinition.typeName() + "\")", ValidatableField.class, methodName)
+						.build();
+			}
 		} else {
 			return FieldSpec.builder(TypeName.get(field.type()), field.name(), Modifier.PRIVATE)
 					.build();
@@ -218,11 +237,18 @@ public class BuilderTypeSpecFactory {
 
 	protected String toConstructorCallingStatement(ConstructorDefinition constructorDefinition) {
 		return constructorDefinition.parameters().stream()
-				.map(param -> this.buildableFields.stream().anyMatch(f -> Objects.equals(f.name(), param.name()))
-						? String.format("%s%s", param.name(),
-								isAnEnforcedConstructorPolicy() ? ".orElseThrow()"
-										: "")
-						: defaultForType(param.type()))
+				.map(param -> {
+					var matchingField = this.buildableFields.stream()
+							.filter(f -> Objects.equals(f.name(), param.name()))
+							.findFirst();
+					if (matchingField.isEmpty()) {
+						return defaultForType(param.type());
+					}
+					boolean isOptionalInStrict = strategy().contains(Strategy.STRICT)
+							&& matchingField.get().isOptional();
+					return String.format("%s%s", param.name(),
+							isAnEnforcedConstructorPolicy() && !isOptionalInStrict ? ".orElseThrow()" : "");
+				})
 				.collect(Collectors.joining(", "));
 	}
 

--- a/processor/src/test/java/io/jonasg/bob/BobTests.java
+++ b/processor/src/test/java/io/jonasg/bob/BobTests.java
@@ -8,10 +8,8 @@ import org.junit.jupiter.api.Test;
 import io.toolisticon.cute.Cute;
 import io.toolisticon.cute.CuteApi;
 import io.toolisticon.cute.JavaFileObjectUtils;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
-public class BobTests {
+class BobTests {
 
 	@Test
 	void failWhenMultipleConstructorsAreAnnotatedWithBuildableConstructor() {
@@ -96,17 +94,36 @@ public class BobTests {
 				.given()
 				.processors(List.of(BuildableProcessor.class))
 				.andSourceFiles(
-						"/tests/AllConstructorParamsAreBuildableIfHavingMatchingField/AllConstructorParamsAreBuildableIfHavingMatchingField.java")
+						"/tests/DefaultValuesForParamsWithNoneMatchingField/DefaultValuesForParamsWithNoneMatchingField.java")
 				.whenCompiled()
 				.thenExpectThat()
 				.compilationSucceeds()
 				.andThat()
 				.generatedSourceFile(
-						"io.jonasg.bob.test.AllConstructorParamsAreBuildableIfHavingMatchingFieldBuilder")
+						"io.jonasg.bob.test.DefaultValuesForParamsWithNoneMatchingFieldBuilder")
 				.matches(
 						CuteApi.ExpectedFileObjectMatcherKind.BINARY,
 						JavaFileObjectUtils.readFromResource(
-								"/tests/AllConstructorParamsAreBuildableIfHavingMatchingField/Expected_AllConstructorParamsAreBuildableIfHavingMatchingField.java"))
+								"/tests/DefaultValuesForParamsWithNoneMatchingField/Expected_DefaultValuesForParamsWithNoneMatchingField.java"))
+				.executeTest();
+	}
+
+	@Test
+	void excludeFieldsFromBuilder() {
+		Cute.blackBoxTest()
+				.given()
+				.processors(List.of(BuildableProcessor.class))
+				.andSourceFiles(
+						"/tests/ExcludeFieldsFromBuilder/ExcludeFieldsFromBuilder.java")
+				.whenCompiled()
+				.thenExpectThat()
+				.compilationSucceeds()
+				.andThat()
+				.generatedSourceFile("io.jonasg.bob.test.ExcludeFieldsFromBuilderBuilder")
+				.matches(
+						CuteApi.ExpectedFileObjectMatcherKind.BINARY,
+						JavaFileObjectUtils.readFromResource(
+								"/tests/ExcludeFieldsFromBuilder/Expected_ExcludeFieldsFromBuilder.java"))
 				.executeTest();
 	}
 
@@ -248,7 +265,7 @@ public class BobTests {
 	class RecordTests {
 
 		@Test
-		public void recordsAreBuildable() {
+		void recordsAreBuildable() {
 			Cute.blackBoxTest()
 					.given()
 					.processors(List.of(BuildableProcessor.class))

--- a/processor/src/test/java/io/jonasg/bob/StrategyTests.java
+++ b/processor/src/test/java/io/jonasg/bob/StrategyTests.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 public class StrategyTests {
 	@Nested
@@ -138,6 +136,26 @@ public class StrategyTests {
 					.executeTest();
 		}
 
+		@Test
+		void optionalConstructorFieldIsNotEnforced() {
+			Cute.blackBoxTest()
+					.given()
+					.processors(List.of(BuildableProcessor.class))
+					.andSourceFiles(
+							"/tests/Strategies/Strict/OptionalConstructorFieldInStrictStrategy/OptionalConstructorFieldInStrictStrategy.java")
+					.whenCompiled()
+					.thenExpectThat()
+					.compilationSucceeds()
+					.andThat()
+					.generatedSourceFile(
+							"io.jonasg.bob.test.OptionalConstructorFieldInStrictStrategyBuilder")
+					.matches(
+							CuteApi.ExpectedFileObjectMatcherKind.BINARY,
+							JavaFileObjectUtils.readFromResource(
+									"/tests/Strategies/Strict/OptionalConstructorFieldInStrictStrategy/Expected_OptionalConstructorFieldInStrictStrategyBuilder.java"))
+					.executeTest();
+		}
+
 		@Nested
 		class AllowNulls {
 
@@ -198,6 +216,24 @@ public class StrategyTests {
 								CuteApi.ExpectedFileObjectMatcherKind.BINARY,
 								JavaFileObjectUtils.readFromResource(
 										"/tests/Strategies/Strict/AllowNulls/FieldsDeclaredInBuildableAnnotationCanBeSetToNull/Expected_FieldsDeclaredInBuildableAnnotationCanBeSetToNullBuilder.java"))
+						.executeTest();
+			}
+
+			@Test
+			void failWhenOptionalAnnotationIsUsedWithAllowNullsStrategy() {
+				Cute.blackBoxTest()
+						.given()
+						.processors(List.of(BuildableProcessor.class))
+						.andSourceFiles(
+								"/tests/Strategies/Strict/AllowNulls/FailWhenOptionalAnnotationIsUsedWithAllowNullsStrategy/FailWhenOptionalAnnotationIsUsedWithAllowNullsStrategy.java")
+						.whenCompiled()
+						.thenExpectThat()
+						.compilationFails()
+						.andThat()
+						.compilerMessage()
+						.ofKindError()
+						.contains(
+								"ALLOW_NULLS strategy cannot be combined with optional fields, consider removing the optional annotation or remove the ALLOW_NULLS strategy")
 						.executeTest();
 			}
 

--- a/processor/src/test/resources/tests/DefaultValuesForParamsWithNoneMatchingField/Expected_DefaultValuesForParamsWithNoneMatchingField.java
+++ b/processor/src/test/resources/tests/DefaultValuesForParamsWithNoneMatchingField/Expected_DefaultValuesForParamsWithNoneMatchingField.java
@@ -1,7 +1,5 @@
 package io.jonasg.bob.test;
 
-import java.lang.String;
-
 public final class DefaultValuesForParamsWithNoneMatchingFieldBuilder {
   public DefaultValuesForParamsWithNoneMatchingFieldBuilder() {
   }

--- a/processor/src/test/resources/tests/ExcludeFieldsFromBuilder/ExcludeFieldsFromBuilder.java
+++ b/processor/src/test/resources/tests/ExcludeFieldsFromBuilder/ExcludeFieldsFromBuilder.java
@@ -1,0 +1,18 @@
+package io.jonasg.bob.test;
+
+import io.jonasg.bob.Buildable;
+
+@Buildable(excludeFields = {"year"})
+public class ExcludeFieldsFromBuilder {
+	private String make;
+
+	private int year;
+
+	private double engineSize;
+
+	public ExcludeFieldsFromBuilder(String make, int year, double engineSize) {
+		this.make = make;
+		this.year = year;
+		this.engineSize = engineSize;
+	}
+}

--- a/processor/src/test/resources/tests/ExcludeFieldsFromBuilder/Expected_ExcludeFieldsFromBuilder.java
+++ b/processor/src/test/resources/tests/ExcludeFieldsFromBuilder/Expected_ExcludeFieldsFromBuilder.java
@@ -1,0 +1,28 @@
+package io.jonasg.bob.test;
+
+import java.lang.String;
+
+public final class ExcludeFieldsFromBuilderBuilder {
+  private String make;
+
+  private int year;
+
+  private double engineSize;
+
+  public ExcludeFieldsFromBuilderBuilder() {
+  }
+
+  public ExcludeFieldsFromBuilderBuilder make(String make) {
+    this.make = make;
+    return this;
+  }
+
+  public ExcludeFieldsFromBuilderBuilder engineSize(double engineSize) {
+    this.engineSize = engineSize;
+    return this;
+  }
+
+  public ExcludeFieldsFromBuilder build() {
+    return new ExcludeFieldsFromBuilder(make, year, engineSize);
+  }
+}

--- a/processor/src/test/resources/tests/Strategies/Strict/AllowNulls/FailWhenOptionalAnnotationIsUsedWithAllowNullsStrategy/FailWhenOptionalAnnotationIsUsedWithAllowNullsStrategy.java
+++ b/processor/src/test/resources/tests/Strategies/Strict/AllowNulls/FailWhenOptionalAnnotationIsUsedWithAllowNullsStrategy/FailWhenOptionalAnnotationIsUsedWithAllowNullsStrategy.java
@@ -1,0 +1,18 @@
+package io.jonasg.bob.test;
+
+import static io.jonasg.bob.Strategy.ALLOW_NULLS;
+import static io.jonasg.bob.Strategy.STRICT;
+import io.jonasg.bob.Buildable;
+
+@Buildable(strategy = { STRICT, ALLOW_NULLS })
+public class FailWhenOptionalAnnotationIsUsedWithAllowNullsStrategy {
+	private String make;
+
+	@Buildable.Optional
+	private int year;
+
+	public FailWhenOptionalAnnotationIsUsedWithAllowNullsStrategy(String make, int year) {
+		this.make = make;
+		this.year = year;
+	}
+}

--- a/processor/src/test/resources/tests/Strategies/Strict/OptionalConstructorFieldInStrictStrategy/Expected_OptionalConstructorFieldInStrictStrategyBuilder.java
+++ b/processor/src/test/resources/tests/Strategies/Strict/OptionalConstructorFieldInStrictStrategy/Expected_OptionalConstructorFieldInStrictStrategyBuilder.java
@@ -1,0 +1,27 @@
+package io.jonasg.bob.test;
+
+import io.jonasg.bob.ValidatableField;
+import java.lang.String;
+
+public final class OptionalConstructorFieldInStrictStrategyBuilder {
+  private final ValidatableField<String> make = ValidatableField.ofNoneNullableField("make", "OptionalConstructorFieldInStrictStrategy");
+
+  private int year;
+
+  public OptionalConstructorFieldInStrictStrategyBuilder() {
+  }
+
+  public OptionalConstructorFieldInStrictStrategyBuilder make(String make) {
+    this.make.set(make);
+    return this;
+  }
+
+  public OptionalConstructorFieldInStrictStrategyBuilder year(int year) {
+    this.year = year;
+    return this;
+  }
+
+  public OptionalConstructorFieldInStrictStrategy build() {
+    return new OptionalConstructorFieldInStrictStrategy(make.orElseThrow(), year);
+  }
+}

--- a/processor/src/test/resources/tests/Strategies/Strict/OptionalConstructorFieldInStrictStrategy/OptionalConstructorFieldInStrictStrategy.java
+++ b/processor/src/test/resources/tests/Strategies/Strict/OptionalConstructorFieldInStrictStrategy/OptionalConstructorFieldInStrictStrategy.java
@@ -1,0 +1,17 @@
+package io.jonasg.bob.test;
+
+import io.jonasg.bob.Buildable;
+import io.jonasg.bob.Strategy;
+
+@Buildable(strategy = Strategy.STRICT)
+public class OptionalConstructorFieldInStrictStrategy {
+	private String make;
+
+	@Buildable.Optional
+	private int year;
+
+	public OptionalConstructorFieldInStrictStrategy(String make, int year) {
+		this.make = make;
+		this.year = year;
+	}
+}


### PR DESCRIPTION
_fixes #35_

This PR adds support for marking fields as `@Optional` when using the **STRICT** builder strategy, so not all constructor parameters need to be explicitly set via the builder.

I gave this a shot based on the issue description, but mostly based on my own needs — the implementation adds an `@Optional` annotation that can be applied directly on fields, and the **STRICT** strategy will drop the `ValidatableField` wrapper for those fields.

I'm new to this codebase, so I may have missed some edge cases or there might be a cleaner approach. Feedback and suggestions are very welcome!